### PR TITLE
Passing more information to CODES through `UNION_Pass_app_data` in order to run surrogate

### DIFF
--- a/src/benchmarks/jacobi3d.C
+++ b/src/benchmarks/jacobi3d.C
@@ -179,7 +179,8 @@ static int jacobi3d_main(int argc, char **argv) {
   // MPI_Pcontrol(1);
   // startTime = MPI_Wtime();
 
-  for(int iterations = 0; iterations < maxiter; iterations++) {
+  int iterations;
+  for(iterations = 0; iterations < maxiter; iterations++) {
     UNION_Compute(compute_time);
     nanosleep(&tim, NULL);
     // if(myRank == 0) printf("iteration %d\n", iterations);
@@ -304,7 +305,7 @@ static int jacobi3d_main(int argc, char **argv) {
 
   if(myRank == 0) {
     // endTime = MPI_Wtime();
-    printf("Jacobi3D: Completed %d iterations\n", iterations);
+    printf("Jacobi3D: Completed %d iterations\n", iterations + 1);
     // printf("Time elapsed per iteration: %f\n", (endTime - startTime)/(MAX_ITER-5));
   }
 

--- a/src/benchmarks/jacobi3d.C
+++ b/src/benchmarks/jacobi3d.C
@@ -111,6 +111,11 @@ static int jacobi3d_main(int argc, char **argv) {
     //MPI_Abort(UNION_Comm_World, -1);
   }
 
+  struct union_app_data app_data = {
+    .final_iteration = maxiter - 1,
+  };
+  UNION_Pass_app_data(&app_data);
+
   struct timespec tim;
   tim.tv_sec = 0;
   tim.tv_nsec = compute_time;

--- a/src/benchmarks/jacobi3d.C
+++ b/src/benchmarks/jacobi3d.C
@@ -123,7 +123,7 @@ static int jacobi3d_main(int argc, char **argv) {
   int myYcoord = (myRank % (num_blocks_x * num_blocks_y)) / num_blocks_x;
   int myZcoord = myRank / (num_blocks_x * num_blocks_y);
 
-  int iterations = 0, i, j, k;
+  int i, j, k;
   double error = 1.0, max_error = 0.0;
 
   if(myRank == 0) {
@@ -179,8 +179,7 @@ static int jacobi3d_main(int argc, char **argv) {
   // MPI_Pcontrol(1);
   // startTime = MPI_Wtime();
 
-  while(/*error > 0.001 &&*/ iterations < maxiter) {
-    iterations++;
+  for(int iterations = 0; iterations < maxiter; iterations++) {
     UNION_Compute(compute_time);
     nanosleep(&tim, NULL);
     // if(myRank == 0) printf("iteration %d\n", iterations);
@@ -296,6 +295,8 @@ static int jacobi3d_main(int argc, char **argv) {
 
     // if(myRank == 0) printf("Iteration %d %f\n", iterations, max_error);
     if(noBarrier == 0) UNION_MPI_Allreduce(&max_error, &error, 1, UNION_Double, UNION_Op_Max, UNION_Comm_World);
+
+    UNION_Mark_Iteration(iterations);
   } /* end of while loop */
 
   UNION_MPI_Barrier(UNION_Comm_World);

--- a/src/benchmarks/jacobi3d.C
+++ b/src/benchmarks/jacobi3d.C
@@ -310,7 +310,7 @@ static int jacobi3d_main(int argc, char **argv) {
 
   if(myRank == 0) {
     // endTime = MPI_Wtime();
-    printf("Jacobi3D: Completed %d iterations\n", iterations + 1);
+    printf("Jacobi3D: Completed %d iterations\n", iterations);
     // printf("Time elapsed per iteration: %f\n", (endTime - startTime)/(MAX_ITER-5));
   }
 

--- a/src/union_util.h
+++ b/src/union_util.h
@@ -142,6 +142,8 @@ void UNION_MPI_Alltoallv(const void *sendbuf,
             UNION_Datatype recvtype,
             UNION_Comm comm);
 
+void UNION_Mark_Iteration(UNION_TAG iter_tag);
+
 inline void UNION_Type_size(UNION_Datatype type, int* size) {
     *size = type;
 }

--- a/src/union_util.h
+++ b/src/union_util.h
@@ -48,6 +48,10 @@ struct union_conceptual_bench {
     int (*conceptual_main)(int argc, char *argv[]);
 };
 
+struct union_app_data {
+    int final_iteration; // id for final iteration
+};
+
 
 void union_conc_add_bench(
         struct union_conceptual_bench const * method);
@@ -57,6 +61,9 @@ int union_conc_bench_load(
         const char* program,
         int argc,
         char *argv[]);
+
+// Call function before first UNION_MPI call that produces any packets. This function will store the information about the application into a space Union can check and respond from.
+void UNION_Pass_app_data(struct union_app_data *);
 
 void UNION_MPI_Comm_size (UNION_Comm comm, int *size);
 void UNION_MPI_Comm_rank( UNION_Comm comm, int *rank );


### PR DESCRIPTION
I've added a function that the skeleton should call in order to give some information to CODES: `UNION_Pass_app_data` (and `SWM_Pass_app_data`).

The function is currently implemented and accessible in the develop branch of CODES: [codes-conc-online-comm-wrkld.C#L95](https://github.com/codes-org/codes/blob/242707e42e32d52ca9f5cc48c2558d61f2752948/src/workload/methods/codes-conc-online-comm-wrkld.C#L95)

The updated script to compile everything can be found here: [CODES-compile-instructions.sh](https://github.com/codes-org/codes/blob/242707e42e32d52ca9f5cc48c2558d61f2752948/CODES-compile-instructions.sh).

I will be pushing CODES, ROSS and SWM-workloads into master shortly after this pull request is accepted. Yay!! :D